### PR TITLE
Correct the comment character "%" for .m files

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,8 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "#",
+        // Octave's (and MATLAB's) comment symbol is the percent sign. Press Ctrl+Shift+7 in a .m file inside VS Code to comment out lines
+        "lineComment": "%",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "#{", "}#" ]
     },


### PR DESCRIPTION
The comment character in Octave is the percent sign "%", there is an Issue in this repository about the necessity of this change.
EDIT: By the way, I already tested if this works by modifying my local copy of the extension, and now when I press Ctrl+Shift+7 in a .m file in VS Code the lines are commented out as expected