### PR TITLE
Add quotation mark to avoid special char problems e.g. spaces in file names

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -57,7 +57,7 @@ export class Commands implements vscode.Disposable {
         }
         this.terminal.show(preserveFocus);
         this.terminal.sendText(`cd "${this.cwd}"`);
-        this.terminal.sendText(this.COMMANDS + fileName);
+        this.terminal.sendText(this.COMMANDS + `"${fileName}"`);
     }
 
     public executeCommandInOutputChannel(fileName: string, clearPreviousOutput, preserveFocus): void {
@@ -69,7 +69,7 @@ export class Commands implements vscode.Disposable {
         this.outputChannel.appendLine(`[Running] ${basename(fileName)}`);
         const exec = require("child_process").exec;
         const startTime = new Date();
-        this.process = exec(this.COMMANDS + fileName, { cwd: this.cwd });
+        this.process = exec(this.COMMANDS + `"${fileName}"`, { cwd: this.cwd });
 
         this.process.stdout.on("data", (data) => {
             this.outputChannel.append(data);


### PR DESCRIPTION
Extension currently not working for some file names with special characters, for example spaces (shell would interpret as multiple files). Adding quotation marks would make it agnostic to those. Not really sure it's the best solution but should work, maybe reformat to a shell compatible format?
