### PR TITLE
Fix dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-.vsix
-package-lock.json
+*.vsix
 out

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,3 +3,5 @@
 .gitignore
 tsconfig.json
 tslint.json
+src/
+src/**

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -3,7 +3,7 @@
         // symbol used for single line comment. Remove this entry if your language does not support line comments
         "lineComment": "#",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "#{", "}#" ]
+        "blockComment": [ "#{", "#}" ]
     },
     // symbols used as brackets
     "brackets": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "vscode": "^1.17.0"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "license": "MIT",
     "repository": {
@@ -109,9 +109,9 @@
         "tree-kill": "^1.1.0"
     },
     "devDependencies": {
-        "typescript": "^4.6.3"
+        "typescript": "^4.6.3",
         "@types/vscode": "^1.66.0",
         "@types/node": "^7.0.43",
-        "@types/mocha": "^2.2.42",
+        "@types/mocha": "^2.2.42"
     }
 }

--- a/package.json
+++ b/package.json
@@ -103,15 +103,15 @@
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "postinstall": ""
     },
     "dependencies": {
         "tree-kill": "^1.1.0"
     },
     "devDependencies": {
-        "typescript": "^2.6.1",
-        "vscode": "^1.1.6",
+        "typescript": "^4.6.3"
+        "@types/vscode": "^1.66.0",
         "@types/node": "^7.0.43",
-        "@types/mocha": "^2.2.42"
+        "@types/mocha": "^2.2.42",
     }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -2,10 +2,37 @@
     "function": {
         "prefix": "function",
         "body": [
-            "function $1 = $2($3)",
-            "$4",
-            "end"
+            "function ${1:y} = ${2:f}(${3:x})",
+            "\t${4:body}",
+            "endfunction"
         ],
-        "description":"Function"
+        "description": "Function declaration"
+    },
+    "for loop": {
+        "prefix": "for",
+        "body": [
+            "for ${1:i} = ${2:range}",
+            "\t${3:body}",
+            "endfor"
+        ],
+        "description": "'For' loop"
+    },
+    "while loop": {
+        "prefix": "while",
+        "body": [
+            "while ${1:condition}",
+            "\t${2:body}",
+            "endwhile"
+        ],
+        "description": "'While' loop"
+    },
+    "if": {
+        "prefix": "if",
+        "body": [
+            "if ${1:condition}",
+            "\t${2:body}",
+            "endif"
+        ],
+        "description": "If conditional"
     }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 
 export class Commands implements vscode.Disposable {
     private LANGUAGE_NAME  = "Octave";
-    private EXTENTSION_NAME = "octave";
+    private EXTENSION_NAME = "octave";
     private COMMANDS = "octave ";
 
     private outputChannel: vscode.OutputChannel;
@@ -40,7 +40,7 @@ export class Commands implements vscode.Disposable {
         const fileName = basename(this.document.fileName);
         this.cwd = dirname(this.document.fileName);
 
-        this.config = vscode.workspace.getConfiguration(this.EXTENTSION_NAME);
+        this.config = vscode.workspace.getConfiguration(this.EXTENSION_NAME);
         const runInTerminal = this.config.get<boolean>("runInTerminal", true);
         const clearPreviousOutput = this.config.get<boolean>("clearPreviousOutput", true);
         const preserveFocus = this.config.get<boolean>("preserveFocus", true);


### PR DESCRIPTION
The main point of this PR is to fix the development dependencies which were broken for the modern vscode types API, as vscode changed slightly how their types are imported. See f7f384c0822caf3b5237b3ab3c367988c1c5bfc4. So now you actually should be able to build the extension after running `npm install`. HOWEVER, I have not checked whether users would need to update to vscode version ^1.66.0. I have not actually changed any source code, so changing `"@types/vscode": "^1.66.0"` to `"@types/vscode": "^1.17.0"` should be safe.

package-lock.json was removed from the .gitignore for reproducibility of builds (8a36bb49b1b0f733be0e5e7bfdc4069b8c2abc23), I added a few snippets (38fcdf4614d40d4e2174c4d392389bbdcc0369a7), and removed unnecessary files from the installed extension for users (1527c36bca8c71a584f90affe51b430d1a21ffdf).

Besides all that, a few typos and such were fixed in the source code (b314bef93e95e92aff2dff6f615254e4e71fb361, 494dc36da1649c5092edf5411fbf9e3296d37d6c).